### PR TITLE
Added kick and ops plugins

### DIFF
--- a/plugins/kick.rb
+++ b/plugins/kick.rb
@@ -1,0 +1,27 @@
+#encoding: utf-8
+
+class Kick < Botpop::Plugin
+  include Cinch::Plugin
+
+  match(/!k (.+)/, use_prefix: false, method: :exec_kick)
+  match(/!kick (.+)/, use_prefix: false, method: :exec_kick)
+  match(/!k ([^|]+)\|(.+)/, use_prefix: false, method: :exec_kick_message)
+  match(/!kick ([^|]+)\|(.+)/, use_prefix: false, method: :exec_kick_message)
+
+  HELP = ["!kick nickname <message>"]
+  ENABLED = config['enable'].nil? ? true : config['enable']
+  CONFIG = config
+
+  def exec_kick m, victim
+    len = CONFIG["list"].length - 1
+    msg = CONFIG["list"][rand(0..len)]
+    m.channel.kick(victim, msg)
+    m.reply "Bye bye " + victim
+  end
+
+  def exec_kick_message m, victim, reason
+    m.channel.kick(victim, reason)
+    m.reply "Bye bye " + victim
+  end
+
+end

--- a/plugins/ops.rb
+++ b/plugins/ops.rb
@@ -1,0 +1,51 @@
+#encoding: utf-8
+
+class Ops < Botpop::Plugin
+  include Cinch::Plugin
+
+  match(/!op/, use_prefix: false, method: :exec_op)
+  match(/!op (.+)/, use_prefix: false, method: :exec_op_other)
+  match(/!deop/, use_prefix: false, method: :exec_deop)
+  match(/!deop (.+)/, use_prefix: false, method: :exec_deop_other)
+  match(/!v/, use_prefix: false, method: :exec_voice)
+  match(/!v (.+)/, use_prefix: false, method: :exec_voice_other)
+  match(/!dv/, use_prefix: false, method: :exec_devoice)
+  match(/!dv (.+)/, use_prefix: false, method: :exec_devoice_other)
+
+  HELP = ["!op <nickname>", "!deop <nickname>"]
+  ENABLED = config['enable'].nil? ? true : config['enable']
+  CONFIG = config
+
+  def exec_op m
+    m.channel.op(m.user)
+  end
+
+  def exec_op_other m, other
+    m.channel.op(other)
+  end
+
+  def exec_deop m
+    m.channel.deop(m.user)
+  end
+
+  def exec_deop_other m, other
+    m.channel.deop(other)
+  end
+
+  def exec_voice m
+    m.channel.voice(m.user)
+  end
+
+  def exec_voice_other m, other
+    m.channel.voice(other)
+  end
+
+  def exec_devoice m
+    m.channel.devoice(m.user)
+  end
+
+  def exec_devoice_other m, other
+    m.channel.devoice(other)
+  end
+
+end


### PR DESCRIPTION
I added two plugins : kick and ops.
The kick plugin allows the following commands: !k and !kick. The commands ask the bot to kick the target user from the current channel. It requires that the bot has an operator status in the channel in order to work.
The ops plugin allows the following commands: !op, !deop, !v, !dv. The !op command ask the bot to give the operator status to the user. The !deop command asks the bot to remove the operator status from the user. The !v and !dv commands work the same way, except they voice and devoice the user. Those commands require that the bot has an operator status in the channel in order to work.
